### PR TITLE
add Ubuntu Noble | update ament

### DIFF
--- a/.github/workflows/ci-colcon.yaml
+++ b/.github/workflows/ci-colcon.yaml
@@ -29,7 +29,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-22.04]
+        os: [ubuntu-22.04, ubuntu-24.04]
         build-type: [Debug, RelWithDebInfo]
         mc-rtc-version: [head, stable]
         exclude:

--- a/.github/workflows/package.yaml
+++ b/.github/workflows/package.yaml
@@ -26,12 +26,8 @@ jobs:
       main-repo: isri-aist/TrajectoryCollection
       matrix: |
         {
-          "dist": ["focal", "jammy", "noble"],
-          "arch": ["amd64"],
-          "include":
-          [
-            {"dist": "bionic", "arch": "i386" }
-          ]
+          "dist": ["jammy", "noble"],
+          "arch": ["amd64"]
         }
     secrets:
       CLOUDSMITH_API_KEY: ${{ secrets.CLOUDSMITH_API_KEY }}

--- a/.github/workflows/package.yaml
+++ b/.github/workflows/package.yaml
@@ -21,8 +21,18 @@ jobs:
   package:
     uses: jrl-umi3218/github-actions/.github/workflows/package-project.yml@master
     with:
+      latest-cmake: true
       deps: '["isri-aist/BaselineWalkingController"]'
       main-repo: isri-aist/TrajectoryCollection
+      matrix: |
+        {
+          "dist": ["focal", "jammy", "noble"],
+          "arch": ["amd64"],
+          "include":
+          [
+            {"dist": "bionic", "arch": "i386" }
+          ]
+        }
     secrets:
       CLOUDSMITH_API_KEY: ${{ secrets.CLOUDSMITH_API_KEY }}
       GH_TOKEN: ${{ secrets.GH_PAGES_TOKEN }}

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,5 @@
-cmake_minimum_required(VERSION 3.8)
+cmake_minimum_required(VERSION 3.14)
+
 
 set(PROJECT_NAME trajectory_collection)
 set(PROJECT_GENERATED_HEADERS_SKIP_DEPRECATED ON)
@@ -27,8 +28,6 @@ if(USE_ROS2)
 
   include_directories(include ${ament_INCLUDE_DIRS})
   link_directories(${ament_LIBRARY_DIRS})
-
-  ament_package()
 else()
   set(BUILD_TESTING OFF)
   option(BUILD_SHARED_LIBS "Build libraries as shared as opposed to static" ON)
@@ -42,4 +41,8 @@ endif()
 
 if(INSTALL_DOCUMENTATION)
   add_subdirectory(doc)
+endif()
+
+if(USE_ROS2)
+  ament_package()
 endif()


### PR DESCRIPTION
* add Ubuntu 24.04 CI and package generation
* update ament_package() position. As mentioned in the official documentation, it should be the last call of your CMakeLists.txt 

> The project setup is done by ament_package() and this call must occur exactly once per package. ament_package() installs the package.xml, registers the package with the ament index, and installs config (and possibly target) files for CMake so that it can be found by other packages using find_package. Since ament_package() gathers a lot of information from the CMakeLists.txt it should be the last call in your CMakeLists.txt. Although it is possible to follow calls to ament_package() by calls to install functions copying files and directories, it is simpler to just keep ament_package() the last call. [link to doc](https://docs.ros.org/en/foxy/How-To-Guides/Ament-CMake-Documentation.html)